### PR TITLE
2014-11-07 Nightly fix 

### DIFF
--- a/src/ws/server.rs
+++ b/src/ws/server.rs
@@ -38,7 +38,7 @@ pub trait WebSocketServer: Server {
     fn ws_serve_forever(self) {
         let config = self.get_config();
         debug!("About to bind to {}", config.bind_address);
-        let mut acceptor = match TcpListener::bind(config.bind_address.ip.to_string().as_slice(), config.bind_address.port).listen() {
+        let mut acceptor = match TcpListener::bind((config.bind_address.ip.to_string().as_slice(), config.bind_address.port)).listen() {
             Err(err) => {
                 error!("bind or listen failed :-(: {}", err);
                 return;


### PR DESCRIPTION
TcpListener::bind changed from:
`fn bind(addr: &str, port: u16) -> IoResult<TcpListener>`
to:
`fn bind<A: ToSocketAddr>(addr: A) -> IoResult<TcpListener>`
